### PR TITLE
added support for multiple directories

### DIFF
--- a/autoload/MUcompleteMinisnip.vim
+++ b/autoload/MUcompleteMinisnip.vim
@@ -3,12 +3,29 @@ set cpo&vim
 
 let s:cmp = 'stridx(v:val, l:pat) >= 0'
 
+" Get the path separator for this platform.
+function! s:pathsep()
+    for l:w in ['win16', 'win32', 'win64', 'win95']
+        if has(l:w)
+            return ';'
+        endif
+    endfor
+    return ':'
+endfunction
+
 function! MUcompleteMinisnip#candidates() abort
-    let l:global_snippets = map(glob(g:minisnip_dir . '/[^_]*', v:false, v:true), {key, val ->
-        \ fnamemodify(val, ':t')})
-    let l:filetype_snippets = map(glob(g:minisnip_dir . '/_' . &filetype . '_*', v:false,
-        \ v:true), {key, val -> substitute(fnamemodify(val, ':t'), '^_' . &filetype . '_', '',
-        \ '')})
+	if !exists("g:pathsep")
+	  let g:pathsep = s:pathsep()
+	endif
+
+	for l:dir in split(g:minisnip_dir, g:pathsep)
+		echo l:dir
+		let l:global_snippets = map(glob(l:dir . '/[^_]*', v:false, v:true), {key, val ->
+			\ fnamemodify(val, ':t')})
+		let l:filetype_snippets = map(glob(l:dir . '/_' . &filetype . '_*', v:false,
+			\ v:true), {key, val -> substitute(fnamemodify(val, ':t'), '^_' . &filetype . '_', '',
+			\ '')})
+	endfor
     return l:global_snippets + l:filetype_snippets
 endfunction
 

--- a/autoload/MUcompleteMinisnip.vim
+++ b/autoload/MUcompleteMinisnip.vim
@@ -18,10 +18,9 @@ function! MUcompleteMinisnip#candidates() abort
 	  let g:pathsep = s:pathsep()
 	endif
 
+	let l:global_snippets = map(glob(split(g:minisnip_dir, g:pathsep)[0] . '/[^_]*', v:false, v:true), {key, val ->
+		\ fnamemodify(val, ':t')})
 	for l:dir in split(g:minisnip_dir, g:pathsep)
-		echo l:dir
-		let l:global_snippets = map(glob(l:dir . '/[^_]*', v:false, v:true), {key, val ->
-			\ fnamemodify(val, ':t')})
 		let l:filetype_snippets = map(glob(l:dir . '/_' . &filetype . '_*', v:false,
 			\ v:true), {key, val -> substitute(fnamemodify(val, ':t'), '^_' . &filetype . '_', '',
 			\ '')})

--- a/autoload/MUcompleteMinisnip.vim
+++ b/autoload/MUcompleteMinisnip.vim
@@ -17,14 +17,17 @@ function! MUcompleteMinisnip#candidates() abort
 	if !exists("g:pathsep")
 	  let g:pathsep = s:pathsep()
 	endif
-
-	let l:global_snippets = map(glob(split(g:minisnip_dir, g:pathsep)[0] . '/[^_]*', v:false, v:true), {key, val ->
-		\ fnamemodify(val, ':t')})
+	let l:global_snippets = []
+	let l:filetype_snippets = []
 	for l:dir in split(g:minisnip_dir, g:pathsep)
-		let l:filetype_snippets = map(glob(l:dir . '/_' . &filetype . '_*', v:false,
+		let l:global_snippets = l:global_snippets + map(glob(l:dir . '/[^_]*', v:false, v:true), {key, val ->
+			\ fnamemodify(val, ':t')})
+		" echoerr l:global_snippets[0]
+		let l:filetype_snippets = l:filetype_snippets + map(glob(l:dir . '/_' . &filetype . '_*', v:false,
 			\ v:true), {key, val -> substitute(fnamemodify(val, ':t'), '^_' . &filetype . '_', '',
 			\ '')})
 	endfor
+	" echoerr l:global_snippets
     return l:global_snippets + l:filetype_snippets
 endfunction
 

--- a/autoload/MUcompleteMinisnip.vim
+++ b/autoload/MUcompleteMinisnip.vim
@@ -19,15 +19,14 @@ function! MUcompleteMinisnip#candidates() abort
 	endif
 	let l:global_snippets = []
 	let l:filetype_snippets = []
+
 	for l:dir in split(g:minisnip_dir, g:pathsep)
 		let l:global_snippets = l:global_snippets + map(glob(l:dir . '/[^_]*', v:false, v:true), {key, val ->
 			\ fnamemodify(val, ':t')})
-		" echoerr l:global_snippets[0]
 		let l:filetype_snippets = l:filetype_snippets + map(glob(l:dir . '/_' . &filetype . '_*', v:false,
 			\ v:true), {key, val -> substitute(fnamemodify(val, ':t'), '^_' . &filetype . '_', '',
 			\ '')})
 	endfor
-	" echoerr l:global_snippets
     return l:global_snippets + l:filetype_snippets
 endfunction
 


### PR DESCRIPTION
With this change you can use multiple directories for your snippets. This is done by setting 
```
let g:minisnip_dir = '~/.vim/snippets:~/.vim/moresnippets'
```
or if you want to recursively use a directory you can set 
```
let g:minisnip_dir = '~/.vim/snippets:' . join(split(glob('~/.vim/snippets/**/'), '\n'), ':')
```
The only issue right now with using it recursivly is that your directories need to start with `_` to prevent the directories showing up in the completion menu.